### PR TITLE
Revert behavior for numeric input

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,10 @@ var template = _.template("<%= key %> <%= op %> <%= value %>");
 var matchers = { $gt: '>', $gte: '>=', $lt: '<', $lte: '<=', $ne: '!='};
 
 function sqlValue(value) {
-  if (_.isNumber(value)) {
-    return value;
-  } else if (_.isString(value)) {
+  if (_.isString(value)) {
     return "'" + value.replace(/'/g, "''") + "'";
   } else {
-    return "'" + value + "'"; // backwards compatibility for undefined input etc
+    return "'" + value + "'"; // backwards compatibility for numeric input etc
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "where2",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A simple lib that converts a object clause into a sql where clause:",
   "main": "index.js",
   "scripts": {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -8,7 +8,7 @@ test('Happy Path', function(t){
   );
   t.equals(
     w2({foo: 1}),
-    "foo = 1"
+    "foo = '1'"
   );
   t.equals(
     w2({foo: ['bar']}),


### PR DESCRIPTION
The previous implementation broke tests on sql-templar; probably
safer to revert back to treating numeric inputs as strings.
